### PR TITLE
fixed a bug where the linux platform would fail silently

### DIFF
--- a/platform/linux.json
+++ b/platform/linux.json
@@ -3,7 +3,7 @@
 		"command": "paplay",
 		"options": {
 			"volume": {
-				"syntax": "volume=:volume",
+				"syntax": "--volume=:volume",
 				"range": [0, 65536]
 			}
 		}


### PR DESCRIPTION
While using your lib under Ubuntu 15.04 I couldn't get it to work. It just failed silently. Discovered that it was the volume arg for linux that was the culprit. It was missing the --. Just added that and now it works for me on Ubuntu 15.04.
